### PR TITLE
Fix warnings by updating datify to 0.1.4

### DIFF
--- a/.justfile
+++ b/.justfile
@@ -1,9 +1,7 @@
 alias r := run
 run *args:
-  tt run --ppi 100 --no-use-system-fonts --font-path fonts --warnings ignore --expression 'not template()' {{args}}
-  # tt run --ppi 100 --no-use-system-fonts --font-path fonts --expression 'not template()' {{args}}
+  tt run --ppi 100 --no-use-system-fonts --font-path fonts --expression 'not template()' {{args}}
 
 alias u := update
 update *args:
-  tt update --ppi 100 --no-use-system-fonts --font-path fonts --warnings ignore --expression 'not template()' {{args}}
-  # tt update --ppi 100 --no-use-system-fonts --font-path fonts --expression 'not template()' {{args}}
+  tt update --ppi 100 --no-use-system-fonts --font-path fonts --expression 'not template()' {{args}}

--- a/ijimai.typ
+++ b/ijimai.typ
@@ -1,5 +1,5 @@
 #import "@preview/wrap-it:0.1.1": wrap-content
-#import "@preview/datify:0.1.3": custom-date-format, day-name, month-name
+#import "@preview/datify:0.1.4": custom-date-format, day-name, month-name
 #import "@preview/droplet:0.3.1": dropcap
 #let azulunir = rgb("#0098cd")
 


### PR DESCRIPTION
Since there are no warnings, I also updated the `tt` commands. The tests will stay in this branch, we'll see if they will still exist in the main (after the refactoring is done).
